### PR TITLE
feat(lib-storage): resume multipart uploads

### DIFF
--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -4,6 +4,9 @@ import {
   CompleteMultipartUploadCommand,
   CreateMultipartUploadCommand,
   CreateMultipartUploadCommandOutput,
+  ListMultipartUploadsCommand,
+  ListPartsCommand,
+  Part,
   PutObjectCommand,
   PutObjectCommandInput,
   PutObjectCommandOutput,
@@ -23,6 +26,17 @@ export interface RawDataPart {
   data: BodyDataTypes;
   lastPart?: boolean;
 }
+
+interface UploadedPartAttributes {
+  PartNumber: number;
+  ETag: string;
+  ChecksumCRC32?: string;
+  ChecksumCRC32C?: string;
+  ChecksumSHA1?: string;
+  ChecksumSHA256?: string;
+}
+
+type UploadedPartsMap = { [k: number]: UploadedPartAttributes };
 
 const MIN_PART_SIZE = 1024 * 1024 * 5;
 
@@ -56,6 +70,8 @@ export class Upload extends EventEmitter {
 
   private isMultiPart = true;
   private putResponse?: PutObjectCommandOutput;
+
+  private previouslyUploadedPartsMap: UploadedPartsMap = {};
 
   constructor(options: Options) {
     super();
@@ -92,6 +108,65 @@ export class Upload extends EventEmitter {
   on(event: "httpUploadProgress", listener: (progress: Progress) => void): any {
     this.uploadEvent = event;
     super.on(event, listener);
+  }
+
+  async __checkForExistingMultipartUpload() {
+    const { Bucket, Key: Prefix } = this.params;
+    const listUploadsCommandParams = {
+      Bucket,
+      Prefix,
+      MaxUploads: 1,
+    };
+
+    const { Uploads } = await this.client.send(new ListMultipartUploadsCommand(listUploadsCommandParams));
+
+    if (Uploads && Uploads.length > 0) {
+      this.uploadId = Uploads[0].UploadId;
+    }
+  }
+
+  async __getUploadedParts() {
+    if (!this.uploadId) {
+      return;
+    }
+    const { Bucket, Key } = this.params;
+
+    let moreResults = true;
+    let numPartsRetrieved = 0;
+
+    while (moreResults) {
+      moreResults = false;
+
+      const listPartsResponse = await this.client.send(
+        new ListPartsCommand({
+          Bucket,
+          Key,
+          UploadId: this.uploadId,
+          PartNumberMarker: numPartsRetrieved.toString(),
+        })
+      );
+
+      moreResults = !!listPartsResponse.IsTruncated;
+
+      const uploadedParts = listPartsResponse.Parts;
+      if (uploadedParts) {
+        numPartsRetrieved += uploadedParts.length;
+
+        uploadedParts.forEach((part: Part) => {
+          const { ETag, PartNumber } = part;
+          if (ETag && PartNumber) {
+            this.previouslyUploadedPartsMap[PartNumber] = {
+              PartNumber,
+              ETag,
+              ...(part.ChecksumCRC32 && { ChecksumCRC32: part.ChecksumCRC32 }),
+              ...(part.ChecksumCRC32C && { ChecksumCRC32C: part.ChecksumCRC32C }),
+              ...(part.ChecksumSHA1 && { ChecksumSHA1: part.ChecksumSHA1 }),
+              ...(part.ChecksumSHA256 && { ChecksumSHA256: part.ChecksumSHA256 }),
+            };
+          }
+        });
+      }
+    }
   }
 
   async __uploadUsingPut(dataPart: RawDataPart) {
@@ -143,27 +218,41 @@ export class Upload extends EventEmitter {
           }
         }
 
-        const partResult = await this.client.send(
-          new UploadPartCommand({
-            ...this.params,
-            UploadId: this.uploadId,
-            Body: dataPart.data,
+        // If this part was uploaded, use the stored metadata
+        const previouslyUploadedPart = this.previouslyUploadedPartsMap[dataPart.partNumber];
+        if (previouslyUploadedPart) {
+          // TODO: integrity check on dataPart.data
+          this.uploadedParts.push({
+            PartNumber: previouslyUploadedPart.PartNumber,
+            ETag: previouslyUploadedPart.ETag,
+            ...(previouslyUploadedPart.ChecksumCRC32 && { ChecksumCRC32: previouslyUploadedPart.ChecksumCRC32 }),
+            ...(previouslyUploadedPart.ChecksumCRC32C && { ChecksumCRC32C: previouslyUploadedPart.ChecksumCRC32C }),
+            ...(previouslyUploadedPart.ChecksumSHA1 && { ChecksumSHA1: previouslyUploadedPart.ChecksumSHA1 }),
+            ...(previouslyUploadedPart.ChecksumSHA256 && { ChecksumSHA256: previouslyUploadedPart.ChecksumSHA256 }),
+          });
+        } else {
+          const partResult = await this.client.send(
+            new UploadPartCommand({
+              ...this.params,
+              UploadId: this.uploadId,
+              Body: dataPart.data,
+              PartNumber: dataPart.partNumber,
+            })
+          );
+
+          if (this.abortController.signal.aborted) {
+            return;
+          }
+
+          this.uploadedParts.push({
             PartNumber: dataPart.partNumber,
-          })
-        );
-
-        if (this.abortController.signal.aborted) {
-          return;
+            ETag: partResult.ETag,
+            ...(partResult.ChecksumCRC32 && { ChecksumCRC32: partResult.ChecksumCRC32 }),
+            ...(partResult.ChecksumCRC32C && { ChecksumCRC32C: partResult.ChecksumCRC32C }),
+            ...(partResult.ChecksumSHA1 && { ChecksumSHA1: partResult.ChecksumSHA1 }),
+            ...(partResult.ChecksumSHA256 && { ChecksumSHA256: partResult.ChecksumSHA256 }),
+          });
         }
-
-        this.uploadedParts.push({
-          PartNumber: dataPart.partNumber,
-          ETag: partResult.ETag,
-          ...(partResult.ChecksumCRC32 && { ChecksumCRC32: partResult.ChecksumCRC32 }),
-          ...(partResult.ChecksumCRC32C && { ChecksumCRC32C: partResult.ChecksumCRC32C }),
-          ...(partResult.ChecksumSHA1 && { ChecksumSHA1: partResult.ChecksumSHA1 }),
-          ...(partResult.ChecksumSHA256 && { ChecksumSHA256: partResult.ChecksumSHA256 }),
-        });
 
         this.bytesUploadedSoFar += byteLength(dataPart.data);
         this.__notifyProgress({
@@ -190,6 +279,14 @@ export class Upload extends EventEmitter {
   async __doMultipartUpload(): Promise<ServiceOutputTypes> {
     // Set up data input chunks.
     const dataFeeder = getChunk(this.params.Body, this.partSize);
+
+    // Set uploadId if multipart upload exists
+    await this.__checkForExistingMultipartUpload();
+
+    // Retrieve and store metadata for previously uploaded parts
+    if (this.uploadId) {
+      await this.__getUploadedParts();
+    }
 
     // Create and start concurrent uploads.
     for (let index = 0; index < this.queueSize; index++) {

--- a/lib/lib-storage/src/types.ts
+++ b/lib/lib-storage/src/types.ts
@@ -50,4 +50,9 @@ export interface Options extends Partial<Configuration> {
    * This the target where we upload data.
    */
   client: ServiceClients;
+
+  /**
+   * Upload ID for existing upload
+   */
+  uploadId?: string;
 }


### PR DESCRIPTION
### Description
Implement the ability for multipart uploads to be resumed in `lib-storage`.  When starting a multipart upload, check if there is an existing upload and retrieve uploaded parts, and skip uploading those parts again.

### Testing
manual testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
