### PR TITLE
feat(lib-storage): verify uploaded parts when resuming

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -33,8 +33,10 @@
     "@aws-sdk/client-s3": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-crypto/sha256-browser": "2.0.0",
     "@aws-sdk/abort-controller": "*",
     "@aws-sdk/client-s3": "*",
+    "@aws-sdk/util-base64-browser": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.11.2",
     "concurrently": "7.0.0",

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -26,6 +26,8 @@ const listPartsMock = jest.fn().mockResolvedValue({
     {
       PartNumber: 1,
       ETag: "mock-part-ETag",
+      // this was obtained by adding a console.log when calculating in actual code
+      ChecksumSHA256: "eu1MyFbmILcxZCObrKejv2ZFvYB9jcO8XX370ONoEHU=",
     },
   ],
 });
@@ -564,7 +566,7 @@ describe(Upload.name, () => {
     expect(received.length).toBe(1);
   });
 
-  it("should call list parts command and skip uploading part when there is an existing uploadID is provided", async () => {
+  it("should call list parts command and skip uploading part when an uploadID is provided", async () => {
     const largeBuffer = Buffer.from("#".repeat(DEFAULT_PART_SIZE + 10));
     const secondBuffer = largeBuffer.subarray(DEFAULT_PART_SIZE);
     const streamBody = Readable.from(
@@ -601,6 +603,7 @@ describe(Upload.name, () => {
   it("should provide uploadId when multipart upload is created", async () => {
     const partSize = 1024 * 1024 * 5;
     const largeBuffer = Buffer.from("#".repeat(partSize + 10));
+
     const streamBody = Readable.from(
       (function* () {
         yield largeBuffer;

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -1,3 +1,4 @@
+import { Sha256 } from "@aws-crypto/sha256-browser";
 import { AbortController, AbortSignal } from "@aws-sdk/abort-controller";
 import {
   CompletedPart,
@@ -14,6 +15,7 @@ import {
   Tag,
   UploadPartCommand,
 } from "@aws-sdk/client-s3";
+import { toBase64 } from "@aws-sdk/util-base64-browser";
 import { EventEmitter } from "events";
 
 import { byteLength } from "./bytelength";
@@ -29,9 +31,6 @@ export interface RawDataPart {
 interface UploadedPartAttributes {
   PartNumber: number;
   ETag: string;
-  ChecksumCRC32?: string;
-  ChecksumCRC32C?: string;
-  ChecksumSHA1?: string;
   ChecksumSHA256?: string;
 }
 
@@ -64,7 +63,7 @@ export class Upload extends EventEmitter {
   private createMultiPartPromise?: Promise<CreateMultipartUploadCommandOutput>;
 
   private uploadedParts: CompletedPart[] = [];
-  private uploadId?: string;
+  private uploadId?: string | null;
   uploadEvent?: string;
   createdMultipartUploadEvent = "createdMultipartUpload";
 
@@ -151,9 +150,6 @@ export class Upload extends EventEmitter {
             this.previouslyUploadedPartsMap[PartNumber] = {
               PartNumber,
               ETag,
-              ...(part.ChecksumCRC32 && { ChecksumCRC32: part.ChecksumCRC32 }),
-              ...(part.ChecksumCRC32C && { ChecksumCRC32C: part.ChecksumCRC32C }),
-              ...(part.ChecksumSHA1 && { ChecksumSHA1: part.ChecksumSHA1 }),
               ...(part.ChecksumSHA256 && { ChecksumSHA256: part.ChecksumSHA256 }),
             };
           }
@@ -190,6 +186,18 @@ export class Upload extends EventEmitter {
     }
   }
 
+  async __uploadedPartChecksumValid(dataPart: RawDataPart, sha256Checksum: string): Promise<boolean> {
+    const fileData = dataPart.data;
+    if (!(fileData instanceof Uint8Array)) {
+      return false;
+    }
+
+    const hash = new Sha256();
+    hash.update(fileData);
+    const localSha256Checksum = toBase64(await hash.digest());
+    return localSha256Checksum === sha256Checksum;
+  }
+
   async __doConcurrentUpload(dataFeeder: AsyncGenerator<RawDataPart, void, undefined>): Promise<void> {
     for await (const dataPart of dataFeeder) {
       if (this.uploadedParts.length > this.MAX_PARTS) {
@@ -217,21 +225,24 @@ export class Upload extends EventEmitter {
 
         // If this part was uploaded, use the stored metadata
         const previouslyUploadedPart = this.previouslyUploadedPartsMap[dataPart.partNumber];
-        if (previouslyUploadedPart) {
-          // TODO: integrity check on dataPart.data
+        const previouslyUploadedPartValid =
+          previouslyUploadedPart && previouslyUploadedPart.ChecksumSHA256
+            ? await this.__uploadedPartChecksumValid(dataPart, previouslyUploadedPart.ChecksumSHA256)
+            : false;
+
+        // If previously uploaded part is valid, skip uploading again.
+        // Store uploaded part for complete multipart upload request
+        if (previouslyUploadedPartValid) {
           this.uploadedParts.push({
             PartNumber: previouslyUploadedPart.PartNumber,
             ETag: previouslyUploadedPart.ETag,
-            ...(previouslyUploadedPart.ChecksumCRC32 && { ChecksumCRC32: previouslyUploadedPart.ChecksumCRC32 }),
-            ...(previouslyUploadedPart.ChecksumCRC32C && { ChecksumCRC32C: previouslyUploadedPart.ChecksumCRC32C }),
-            ...(previouslyUploadedPart.ChecksumSHA1 && { ChecksumSHA1: previouslyUploadedPart.ChecksumSHA1 }),
             ...(previouslyUploadedPart.ChecksumSHA256 && { ChecksumSHA256: previouslyUploadedPart.ChecksumSHA256 }),
           });
         } else {
           const partResult = await this.client.send(
             new UploadPartCommand({
               ...this.params,
-              UploadId: this.uploadId,
+              UploadId: <string>this.uploadId,
               Body: dataPart.data,
               PartNumber: dataPart.partNumber,
             })
@@ -244,9 +255,6 @@ export class Upload extends EventEmitter {
           this.uploadedParts.push({
             PartNumber: dataPart.partNumber,
             ETag: partResult.ETag,
-            ...(partResult.ChecksumCRC32 && { ChecksumCRC32: partResult.ChecksumCRC32 }),
-            ...(partResult.ChecksumCRC32C && { ChecksumCRC32C: partResult.ChecksumCRC32C }),
-            ...(partResult.ChecksumSHA1 && { ChecksumSHA1: partResult.ChecksumSHA1 }),
             ...(partResult.ChecksumSHA256 && { ChecksumSHA256: partResult.ChecksumSHA256 }),
           });
         }
@@ -308,7 +316,7 @@ export class Upload extends EventEmitter {
       const uploadCompleteParams = {
         ...this.params,
         Body: undefined,
-        UploadId: this.uploadId,
+        UploadId: <string>this.uploadId,
         MultipartUpload: {
           Parts: this.uploadedParts,
         },


### PR DESCRIPTION
### Issue
[Shortcut Ticket](https://app.shortcut.com/idseq/story/189546)

### Description
- Remove attributes checksum algorithms that we don't currently verify.
- When resuming uploads, verify checksum of uploaded parts against local file parts

## Notes
- `x-amz-checksum-sha256` header needs to be exposed in CORS config for bucket to be able to receive SHA-256 checksum from AWS.  This was configured in our terraform repo: chanzuckerberg/idseq-infra#587.

### Testing
Manually tested in CZ ID web app

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
